### PR TITLE
feat(ui): add the animation that lets cover be in center when no file input and move to original position when file input is present

### DIFF
--- a/index.css
+++ b/index.css
@@ -185,6 +185,36 @@ p {
     width: 55vw;
 }
 
+/* 没有选中文件时收缩右侧，左侧占满页面 */
+body.no-files .rightcontent {
+    width: 0;
+    min-width: 0;
+    overflow: hidden;
+    transition: width 0.75s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+body.no-files .leftcontent {
+    width: 100vw;
+    transition: width 0.75s cubic-bezier(0.22, 1, 0.36, 1), transform 0.75s cubic-bezier(0.22, 1, 0.36, 1);
+    transform: translateX(0);
+}
+
+/* 选择文件后展开右侧，左侧向左移动 */
+body:not(.no-files) .rightcontent {
+    width: 55vw;
+    transition: width 0.8s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+body:not(.no-files) .leftcontent {
+    width: 50vw;
+    transition: width 0.8s cubic-bezier(0.22, 1, 0.36, 1), transform 0.8s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+/* 微调svg容器过渡，使封面在移动时显得平滑 */
+.svgcontainer {
+    transition: all 0.75s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
 .lyricscontainer {
     height: 100vh;
     position: relative;

--- a/index.js
+++ b/index.js
@@ -47,6 +47,10 @@ mainDivScalePosition(width, height);
 */
 let bgImg = new Image();
 bgImg.src = "./default.svg";
+
+// 初始状态：无文件输入，收起右侧区域并使左侧内容居中显示默认封面/按钮/标题
+document.body.classList.add('no-files');
+
 let playing = false;
 let isDragging = false;
 let lrcData;
@@ -99,6 +103,11 @@ audioPlayer.addEventListener("loadedmetadata", () => {
 audioFileInput.addEventListener("change", async (event) => {
     const files = event.target.files;
     if (files.length === 0) return;
+
+    // 选择文件后展开右侧并触发左侧非线性移动动画
+    requestAnimationFrame(() => {
+        document.body.classList.remove('no-files');
+    });
 
     for (const file of files) {
         const fileURL = URL.createObjectURL(file);


### PR DESCRIPTION
本更新添加了：

- 默认无文件输入的情况下隐藏右侧歌词部分，让左侧播放器内容居页面中央显示。
- 有文件输入时显示右侧歌词部分，播放器内容通过自然的非线性动画过渡到左侧。

求过求过🙏